### PR TITLE
Bump `actions/cache` to `4.0.0`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Query dependencies
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Restore R package cache
         if: runner.os != 'Windows'
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,8 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'release', rspm: "https://packagemanager.posit.co/cran/latest"}
-          - {os: macOS-latest, r: 'release', rspm: "https://packagemanager.posit.co/cran/latest"}
+          - {os: windows-latest, r: 'release'}
+          - {os: macOS-latest, r: 'release'}
           - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.posit.co/cran/latest"}
           - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.posit.co/cran/latest"}
 
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -24,8 +24,8 @@ jobs:
         config:
           - {os: windows-latest, r: 'release'}
           - {os: macOS-latest, r: 'release'}
-          - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.posit.co/cran/latest"}
+          - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.posit.co/cran/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,8 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'release'}
-          - {os: macOS-latest, r: 'release'}
+          - {os: windows-latest, r: 'release', rspm: "https://packagemanager.posit.co/cran/latest"}
+          - {os: macOS-latest, r: 'release', rspm: "https://packagemanager.posit.co/cran/latest"}
           - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.posit.co/cran/latest"}
           - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.posit.co/cran/latest"}
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -28,6 +28,7 @@ jobs:
           - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.posit.co/cran/latest"}
 
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Attempt to resolve action issues (e.g. [this](https://github.com/mdsteiner/EFAtools/actions/runs/25043706360/job/73353168958) failing job) owing to the use of an [older version](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down) of `actions/cache`.