### PR TITLE
Misleading message from `.efa_pooled_fit_indices`

### DIFF
--- a/R/EFA_POOLED.R
+++ b/R/EFA_POOLED.R
@@ -786,7 +786,7 @@ EFA_POOLED <- function(data_list,
   ## CAF in EFAtools is 1 - KMO(delta_hat), with diagonal set to 1.
   delta_hat <- residuals
   diag(delta_hat) <- 1
-  CAF <- tryCatch(1 - KMO(delta_hat)$KMO,
+  CAF <- tryCatch(1 - KMO(cor(delta_hat))$KMO,
                   error = function(e) NA_real_)
 
   out <- list(


### PR DESCRIPTION
Function [`.efa_pooled_fit_indices`](https://github.com/mdsteiner/EFAtools/blob/46652fcf2b656052fc2541e671f7a4f807f23593/R/EFA_POOLED.R#L686) uses function `KMO` on `delta_hat` here:

https://github.com/mdsteiner/EFAtools/blob/46652fcf2b656052fc2541e671f7a4f807f23593/R/EFA_POOLED.R#L789-L790

I have identified a case where `EFAtools:::.is_cormat(delta_hat)` returns `FALSE`. Consequently, `KMO` prints in the console the following expected message:

```
ℹ 'x' was not a correlation matrix. Correlations are found from entered raw data.
```

This can mislead the user into thinking that `EFA_POOLED`, not `.efa_pooled_fit_indices` (which is internal anyway so the user has no clue it exists), is in fact the function that prints this message, subsequently tricking the user into thinking that supplying the data as correlations has been ignored by `EFA_POOLED`.

The simple fix proposed in this PR: replace `KMO(delta_hat)$KMO` with `KMO(cor(delta_hat))$KMO`.